### PR TITLE
Add bottom tab navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,34 +1,71 @@
 import React, { Component } from 'react';
 import Main from './Component/Main';
-import Header from './Component/Header';
 import AddEvent from './Component/AddEvent';
 import Settings from './Component/Settings';
 
-import { View, Text } from 'react-native';
-import { createStackNavigator } from 'react-navigation';
+import {
+    createBottomTabNavigator,
+    createStackNavigator,
+} from 'react-navigation';
+import createStyles from './Component/Footer';
 
 
-const RootStack = createStackNavigator(
-	{
-	Home: {
-		screen: Main,
-	},
-	AddEv: AddEvent,
-	Settings: Settings,
-	},
-	{
-		initialRouteName: 'Home',
-	}
+const HomeStack = createStackNavigator(
+    {
+        Home: {
+            screen: Main,
+        },
+        AddEv: AddEvent,
+    },
+    {
+        initialRouteName: 'Home',
+    }
 );
 
-export default class App extends React.Component {
+const SettingsStack = createStackNavigator(
+    {
+        Settings: Settings,
+    },
+    {
+        initialRouteName: 'Settings',
+    }
+);
+
+const styles = createStyles({
+    footer: {
+        height: 60
+    }
+});
+
+const TabStack = createBottomTabNavigator(
+    {
+		Events: Main,
+		two : Main,
+        Home: HomeStack,
+		four: Main,
+        Settings: SettingsStack,
+    },
+    {
+        initialRouteName: 'Home',
+		tabBarOptions: {
+            activeTintColor: '#1EEEEE' ,
+			activeBackgroundColor: '#E91E63',
+			inactiveTintColor: '#777777',
+			inactiveBackgroundColor: '#FFAAEE',
+			style: styles.footer,
+            labelStyle: styles.footerText,
+			tabStyle: styles.footerButtons
+		}
+    }
+);
+
+export default class App extends Component {
 	render() {
 		return (
-			<RootStack />
+			<TabStack />
 		);
 	}
 }
-
 
 // export default class App extends Component {
 

--- a/Component/Footer.js
+++ b/Component/Footer.js
@@ -7,7 +7,7 @@ import {
   TouchableOpacity
 } from 'react-native';
 
-export default class Footer extends Component<Props> {
+class Footer extends Component<Props> {
 
   SettingsPage() {
     this.props.goToSettings();
@@ -51,7 +51,7 @@ export default class Footer extends Component<Props> {
   }
 }
 
-const styles = StyleSheet.create({
+const styles = ({
   footer: {
     position: 'absolute',
     bottom: 0,
@@ -73,3 +73,7 @@ const styles = StyleSheet.create({
     padding: 4
   }
 });
+
+export default function createStyles(overrides = {}) {
+    return StyleSheet.create({...styles, ...overrides})
+}

--- a/Component/Main.js
+++ b/Component/Main.js
@@ -32,7 +32,7 @@ export default class Main extends Component {
       <View style={styles.container}>
 
         <Header addNewEvent={this.GoToAddEvent.bind(this)}/>
-        <Footer goToSettings={this.GoToSettingsPage.bind(this)}/>
+        {/*<Footer goToSettings={this.GoToSettingsPage.bind(this)}/>*/}
       </View>
     );
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28438978/41188964-7f2507dc-6bf9-11e8-9283-12a30f0c3212.png)
![image](https://user-images.githubusercontent.com/28438978/41188976-a2c179a0-6bf9-11e8-8b03-3acab58865a3.png)
The bottom tab is the main navigator now, and will persist through all screens (home, settings etc). Pressing the back button when on the home screen closes the app, while doing so on any other screen returns to home.

I'm having problems properly applying the stylesheet though so it looks pretty ugly. 
References: 
[createBottomTabNavigator](https://reactnavigation.org/docs/en/bottom-tab-navigator.html)
[Tab navigation](https://reactnavigation.org/docs/en/tab-based-navigation.html)